### PR TITLE
Add brace-style rule to eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,6 @@ module.exports = {
     curly: ["error", "all"],
     "no-console": ["error", { allow: ["info", "warn", "error"] }],
     "no-use-before-define": ["error", { functions: false, classes: false }],
+    "brace-style": ["error", "1tbs", { allowSingleLine: false }],
   },
 };


### PR DESCRIPTION
Add the `"brace-style": ["error", "1tbs", { allowSingleLine: false }] ` rule to the .eslintrc.js file.